### PR TITLE
Tutorial Review

### DIFF
--- a/HelloWorld.md
+++ b/HelloWorld.md
@@ -1,6 +1,6 @@
-# Hello World!  Your first Solace app
+# Hello World!  Your first Solace Messaging app
 
-Hello and welcome to your first Solace app tutorial.  Appropriately, we’ll be looking at the sample called “HelloWorld”.  At first glance, this application defintitely seems longer than the first Java, Python, C++, Go, Node etc. program you might have ever written.  E.g.:
+Hello and welcome to your first Solace Messaging app tutorial.  Appropriately, we’ll be looking at the sample called “HelloWorld”.  At first glance, this application defintitely seems longer than the first Java, Python, C++, Go, Node etc. program you might have ever written.  E.g.:
 
 ```
 public static void main(String... args) {
@@ -8,7 +8,7 @@ public static void main(String... args) {
 }
 ```
 
-However, as you can tell from this [Wikipedia article](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program), there are many different types of _Hello World_ programs.  Rather than trying to do the bare minimum to produce some visual output, this Solace Hello World will demonstrate some very _fundamental_ and basic features of Solace APIs and pub/sub messaging:
+However, as you can tell from this [Wikipedia article](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program), there are many different types of _Hello World_ programs.  Rather than trying to do the bare minimum to produce some visual output, this Solace Hello World will demonstrate some very _fundamental_ and basic features of Solace Messaging APIs and pub/sub messaging:
 
 - **Publish and Subscribe:** most Solace applications do both the “I” and “O” in I/O
 - **Dynamic topics:** topics are hierarchical and descriptive, not static
@@ -16,7 +16,7 @@ However, as you can tell from this [Wikipedia article](https://en.wikipedia.org/
 - **Asynchronous message receipt:** use of callback handlers
 - **Connection lifecycle management:** connect once, and stay online for the lifetime of the app
 
-This app will connect to a Solace event broker, and publish/subscribe in a loop.  Let’s begin!
+This app will connect to a Solace PubSub+ Event Broker, and publish/subscribe in a loop.  Let’s begin!
 
 ## 1. Command line arguments
 The first couple lines of the program simply read in connection parameters from the console:
@@ -24,8 +24,8 @@ The first couple lines of the program simply read in connection parameters from 
 [![image](https://user-images.githubusercontent.com/7603332/151020098-f912987b-7403-47e4-a3f4-0ce57844deda.png)](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/275739cb858cacea5140c5c7c8310cfb50868695/src/main/java/com/solace/samples/jcsmp/HelloWorld.java#L47-L53)
 
 Specifically, for Solace Native (SMF) APIs, we need to know
-- Broker / host IP address or hostname
-    - E.g. `localhost`, `192.168.42.35`, `mr-abc123.messaging.solace.cloud`
+- Broker / host IP address or hostname and port
+    - E.g. `localhost:55554`, `192.168.42.35:55555`, `mr-abc123.messaging.solace.cloud:55555`
 - Message VPN: a virtual partition of a single broker, how Solace supports multitenancy
      - E.g. `default`, `lab-vpn`, `cloud-demo-singapore`
 - Username
@@ -35,7 +35,7 @@ Specifically, for Solace Native (SMF) APIs, we need to know
 
 
 ## 2. Enter your name
-This part is certainly not required in production applications, but allows Hello World allows to easily build a dynamic topic based on some input. It is also useful if running multiple instances of this application, to see them "talking" to each other, as we’ll see later.
+This part is certainly not required in production applications, but allows Hello World to easily build a dynamic topic based on some input. It is also useful if running multiple instances of this application, to see them "talking" to each other, as we’ll see later.
 
 [![image](https://user-images.githubusercontent.com/7603332/151020807-8b6eea29-7140-4ca2-ac17-aa2721fce467.png)](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/275739cb858cacea5140c5c7c8310cfb50868695/src/main/java/com/solace/samples/jcsmp/HelloWorld.java#L54-L60)
 
@@ -49,11 +49,11 @@ The additional property set “reapply subscriptions” is very useful for appli
 
 
 ## 4. Setup Producer
-The “producer” or publisher in Solace APIs is the component that sends message to the Solace broker.  The producer can be configured to send both Direct and Guaranteed messages on the same session, as well as transactions and other qualities-of-service.
+The “producer” or publisher in Solace Messaging APIs is the component that sends messages to the broker.  The producer can be configured to send both Direct and Guaranteed messages on the same session, as well as transactions and other qualities-of-service.
 
 [![image](https://user-images.githubusercontent.com/7603332/151021534-e1e19590-b118-4f47-80cd-4c3752d86894.png)](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/275739cb858cacea5140c5c7c8310cfb50868695/src/main/java/com/solace/samples/jcsmp/HelloWorld.java#L76-L90)
 
-The producer configuration options vary from API to API.  In JCSMP, you specify two callback handlers.  These are mostly used for Guaranteed messaging applications, to receive “ACKs” (successful acknowledgements) and “NACKs” (negative acknowledgements) from the broker.  As our Hello Word app uses only Direct messaging, these are not as useful, but still need to be configured regardless.  In Python or the PubSub+ Messaging API for Java, Direct publishers do not have to configure this.
+The producer configuration options vary from API to API.  In JCSMP, you specify two callback handlers.  These are mostly used for Guaranteed messaging applications, to receive “ACKs” (successful acknowledgements) and “NACKs” (negative acknowledgements) from the broker.  As our Hello World app uses only Direct messaging, these are not as useful, but still need to be configured regardless.  In the PubSub+ Messaging API for Python or Java, Direct publishers do not have to configure this.
 
 
 ## 5. Setup Consumer
@@ -61,7 +61,7 @@ The next part of the sample sets up the ability to receive messages from the bro
 
 [![image](https://user-images.githubusercontent.com/7603332/151021631-eb569c26-1d6b-4188-bf56-dd80ae1e02fc.png)](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/275739cb858cacea5140c5c7c8310cfb50868695/src/main/java/com/solace/samples/jcsmp/HelloWorld.java#L92-L107)
 
-As you can see, `the onReceive()` callback does not do very much in this simple application, it simply outputs the message to the screen, and continues.
+As you can see, the `onReceive()` callback, which gets triggered for each message that this Consumer receives, does not do very much in this simple application, it simply outputs the message to the screen, and continues.
 
 
 ## 6. Add Direct message subscriptions
@@ -72,7 +72,6 @@ To receive messages from the broker, you have to tell it what you want to receiv
 Notice a few things:
 - The topic subscription is hierarchical: there are “`/`” characters between levels
 - The use of “`*`” and “`>`” wildcard characters in the subscription
-- Direct subscription (not using Guaranteed delivery yet)
 
 These are called a single-level and multi-level wildcard respectively.  The "`*`" will match anything up to the next level, including empty-string; for the multi-level, as long as the message’s first part of the topic matches the subscription to that point, the :`>`" wildcard will match any remaining (one-or-more) levels.  See here for more details topics and on wildcards.
 
@@ -85,13 +84,13 @@ Now we are ready to send some messages, and the subscription will allow us to re
 
 [![image](https://user-images.githubusercontent.com/7603332/151022209-8e0351c8-7e7f-476b-999b-5db055e01be4.png)](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/275739cb858cacea5140c5c7c8310cfb50868695/src/main/java/com/solace/samples/jcsmp/HelloWorld.java#L115-L135)
 
-Note that we specify the payload each loop (could be a text `String`, or a binary `byte[]` payload, etc.), as well as define what the message's published topic is.  Recall: topics are not configured in the Solace broker, they are metadata of the message, and a pattern matching (via subscriptions) is done on each received message.
+Note that we specify the payload each loop (could be a text `String`, or a binary `byte[]` payload, etc.), as well as define what the message's published topic is.  Recall: topics are not configured in the Solace PubSub+ Event Broker, they are metadata of the message, and a pattern matching (via subscriptions) is done on each received message.
 
 
 ## 8. Run it again!
 
-Running this application once is ok to ensure you have broker connectivity, but event-driven technologies like Solace are all about decoupled architectures: you need multiple applications to communicate asynchronously.  So split your terminal, or get a second screen, and try running it again.
-Note that you could run a different language for your 2nd instance, or even another protocol that Solace supports (e.g. REST, MQTT, AMQP 1.0).  Just ensure your topics match the subscriptions.
+Running this application once is ok to ensure you have broker connectivity, but event-driven technologies like the PubSub+ Event Broker are all about decoupled architectures: you need multiple applications to communicate asynchronously.  So split your terminal, or get a second screen, and try running it again.
+Note that you could run a different language for your 2nd instance, or even another protocol that PubSub+ supports (e.g. REST, MQTT, AMQP 1.0).  Just ensure your topics match the subscriptions.
  
 Here is the Python HelloWorld app talking to the Java JCSMP HelloWorld app.  Both are subscribed using wildcards, one subscription each, and they will match topics published by other API flavours: note the published topic for each is different (more for demonstration purposes than anything).
 
@@ -104,9 +103,3 @@ Got a handle on how a basic Solace native app sends and receives messages?  Wond
 - Message payload transformation using Processor pattern
 - Request-Reply using blocking call (not everything needs to be asynchronous)
 - Guaranteed messaging publish-subscribe
-
-
-
-
-
-


### PR DESCRIPTION
Overall looks pretty good! It seems like it would work for any SMF API which is great. Just have to sub in/out the code snippets. 

I made a bunch of small changes in-line, but here are a few more suggestions: 
1. I think this is API specific and not needed in the newer APIs? Suggest removing and making more clear in a comment in the actual sample code if not already explained. 
> The additional property set “reapply subscriptions” is very useful for applications using Direct messaging (e.g. at-most-once delivery): it tells the API that following a reconnection (either due to network flap or broker failover), the API should automatically add any subscriptions back; by default, this set to false and the application would be responsible.

2. Wrong topic used in image under part 6 (you probably already know this, but just in case) 
3. Add a link to the actual code sample somewhere near the top
4. Add a prereq that says something like you need access to a solace pubsub+ event broker; easy ways to get started are with docker or with cloud (use the links from the top of solace.dev) 
5. This is the first time you are mentioning this, did you mean to include it higher up? 
> Recall: topics are not configured in the Solace broker, they are metadata of the message, and a pattern matching (via subscriptions) is done on each received message.
